### PR TITLE
feat: document to bson type

### DIFF
--- a/src/dustdata.rs
+++ b/src/dustdata.rs
@@ -113,8 +113,8 @@ impl DustData {
     /// # Arguments
     /// - `key`: a key to search for
     /// # Returns
-    /// - `Some(bson::Document)` if value was found returns a bson document
-    pub fn get(&self, key: &str) -> Result<Option<bson::Document>> {
+    /// - `Result<Option<(bson::Bson)>>` if value was found returns a bson document
+    pub fn get(&self, key: &str) -> Result<Option<bson::Bson>> {
         self.lsm.get(key)
     }
 
@@ -122,8 +122,8 @@ impl DustData {
     /// # Arguments
     /// - `key`: a key.
     /// - `document`: a bson document to insert
-    pub fn insert(&mut self, key: &str, document: bson::Document) -> Result<()> {
-        self.lsm.insert(key, document)
+    pub fn insert(&mut self, key: &str, bson: bson::Bson) -> Result<()> {
+        self.lsm.insert(key, bson)
     }
 
     /// Delete a value with a key
@@ -137,8 +137,8 @@ impl DustData {
     /// # Arguments
     /// - `key`: a key to search for and update it.
     /// - `document`: the new document to replace the old one.
-    pub fn update(&mut self, key: &str, document: bson::Document) -> Result<()> {
-        self.lsm.update(key, document)
+    pub fn update(&mut self, key: &str, bson: bson::Bson) -> Result<()> {
+        self.lsm.update(key, bson)
     }
 
     /// Check if key exists.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@ mod dustdata_tests {
 
         dd.insert(
             "insert_doc",
-            bson::doc! {
+            bson::bson!({
                 "test": "test"
-            },
+            }),
         )
         .unwrap();
 
@@ -54,21 +54,22 @@ mod dustdata_tests {
         let mut dd = initialize(config);
         dd.insert(
             "update_doc",
-            bson::doc! {
+            bson::bson!({
                 "test": "test"
-            },
+            }),
         )
         .unwrap();
 
         dd.update(
             "update_doc",
-            bson::doc! {
+            bson::bson! ({
                 "test": "test2"
-            },
+            }),
         )
         .unwrap();
 
         let get = dd.get("update_doc").unwrap().unwrap();
+        let get = get.as_document().unwrap();
 
         let get = get.get("test").unwrap().as_str().unwrap();
 

--- a/src/storage/lsm/mod.rs
+++ b/src/storage/lsm/mod.rs
@@ -22,7 +22,7 @@ pub struct LsmConfig {
 
 #[derive(Clone)]
 pub struct Lsm {
-    pub memtable: Arc<Mutex<BTreeMap<String, bson::Document>>>,
+    pub memtable: Arc<Mutex<BTreeMap<String, bson::Bson>>>,
     pub memtable_size: usize,
     pub lsm_config: LsmConfig,
     pub dense_index: Arc<Mutex<HashMap<String, String>>>,
@@ -96,7 +96,7 @@ impl Lsm {
         .ok();
     }
 
-    pub fn insert(&mut self, key: &str, value: bson::Document) -> Result<()> {
+    pub fn insert(&mut self, key: &str, value: bson::Bson) -> Result<()> {
         if self.contains(key) {
             return Err(Error {
                 code: ErrorCode::KeyExists,
@@ -117,14 +117,14 @@ impl Lsm {
         Ok(())
     }
 
-    pub fn get(&self, key: &str) -> Result<Option<bson::Document>> {
+    pub fn get(&self, key: &str) -> Result<Option<bson::Bson>> {
         if !self.contains(key) {
             return Ok(None);
         }
 
-        let document = self.memtable.lock().unwrap();
+        let memtable = self.memtable.lock().unwrap();
 
-        match document.get(&key.to_string()) {
+        match memtable.get(&key.to_string()) {
             Some(document) => Ok(Some(document.clone())),
             None => {
                 let dense_index = self.dense_index.lock().unwrap();
@@ -156,7 +156,7 @@ impl Lsm {
         Ok(())
     }
 
-    pub fn update(&mut self, key: &str, value: bson::Document) -> Result<()> {
+    pub fn update(&mut self, key: &str, value: bson::Bson) -> Result<()> {
         if !self.contains(key) {
             return Err(Error {
                 code: ErrorCode::KeyNotExists,
@@ -187,7 +187,7 @@ impl Lsm {
         self.memtable_size = 0;
     }
 
-    pub fn get_memtable(&self) -> BTreeMap<String, bson::Document> {
+    pub fn get_memtable(&self) -> BTreeMap<String, bson::Bson> {
         self.memtable.lock().unwrap().clone()
     }
 

--- a/src/storage/lsm/sstable.rs
+++ b/src/storage/lsm/sstable.rs
@@ -89,7 +89,7 @@ impl Segment {
         }
     }
 
-    pub fn read_with_offset(offset: String, path: String) -> Option<bson::Document> {
+    pub fn read_with_offset(offset: String, path: String) -> Option<bson::Bson> {
         let splited_offset = offset.split('_').collect::<Vec<&str>>();
         let file_index = splited_offset[0].parse::<u64>().unwrap();
         let offset = splited_offset[1].parse::<u64>().unwrap();
@@ -114,16 +114,16 @@ impl Segment {
 
         let document: Document = bson::from_slice(&document_bytes).unwrap();
 
-        Some(document.get_document("_value").unwrap().clone())
+        Some(document.get("_value").unwrap().clone())
     }
 
-    pub fn write(&mut self, key: &str, value: bson::Document) -> (String, String) {
+    pub fn write(&mut self, key: &str, value: bson::Bson) -> (String, String) {
         // Returns the key and the offset to put in sparse index
         (key.to_string(), self.persist(key, value).unwrap())
     }
 
     pub fn from_tree(
-        tree: &BTreeMap<String, bson::Document>,
+        tree: &BTreeMap<String, bson::Bson>,
         path: &str,
     ) -> (Segment, Vec<(String, String)>) {
         let mut segment = Segment::new(path);

--- a/src/storage/lsm/writer.rs
+++ b/src/storage/lsm/writer.rs
@@ -10,7 +10,7 @@ pub trait Writer {
     /// # Returns
     /// - `Ok(String)` if the write was successful returns the offset
     /// - `Err(())` if the write failed
-    fn persist(&mut self, key: &str, value: bson::Document) -> Result<String, String> {
+    fn persist(&mut self, key: &str, value: bson::Bson) -> Result<String, String> {
         let temp_doc = bson::doc! {
             "_key": key,
             "_value": value,


### PR DESCRIPTION
Changing document type to `BSON` to support: 
 * **Arrays**
 * **Strings**
 * **Numbers**
 * **Boolean**
And more...